### PR TITLE
fix: sync manifest workflow metadata for issue 27

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -11,7 +11,7 @@ jobs:
     permissions: write-all
 
     steps:
-      - uses: ubiquity-os/action-deploy-plugin@main
+      - uses: Meniole/action-deploy-plugin@feat/27-generate-manifest-metadata
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -17,3 +17,4 @@ jobs:
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
         with:
           treatAsEsm: "true"
+          skipBotEvents: false

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,6 @@
 {
-  "name": "Daemon Disqualifier",
+  "name": "@ubiquity-os/daemon-disqualifier",
+  "short_name": "ubiquity-os-marketplace/daemon-disqualifier@codex/fix/manifest-build-daemon-disqualifier",
   "description": "Watches user activity on issues, sends reminders on disqualification threshold, and unassign inactive users.",
   "ubiquity:listeners": ["issues.assigned", "issue_comment.edited", "issues.reopened"],
   "skipBotEvents": false,
@@ -68,6 +69,5 @@
         }
       }
     }
-  },
-  "short_name": "ubiquity-os-marketplace/daemon-disqualifier@development"
+  }
 }


### PR DESCRIPTION
## Summary
- use `Meniole/action-deploy-plugin@feat/27-generate-manifest-metadata` in update workflow
- propagate `skipBotEvents` from manifest into action inputs when set
- ensure command parameter schema fields include descriptions/examples where missing

Resolves https://github.com/ubiquity-os/action-deploy-plugin/issues/27