### PR TITLE
fix(cron): resolve plugin manifests from dist branches

### DIFF
--- a/src/cron/configuration.ts
+++ b/src/cron/configuration.ts
@@ -1,0 +1,46 @@
+import { Value } from "@sinclair/typebox/value";
+import { ConfigurationHandler, isGithubPlugin } from "@ubiquity-os/plugin-sdk/configuration";
+import manifest from "../../manifest.json" with { type: "json" };
+import { ContextPlugin, PluginSettings, pluginSettingsSchema } from "../types/plugin-input";
+
+type ManifestPlugin = Parameters<ConfigurationHandler["getManifest"]>[0];
+
+function getDistRef(ref: string) {
+  return ref.startsWith("dist/") ? ref : `dist/${ref}`;
+}
+
+export class CronConfigurationHandler extends ConfigurationHandler {
+  override async getManifest(plugin: ManifestPlugin) {
+    if (!isGithubPlugin(plugin) || !plugin.ref || plugin.ref.startsWith("dist/")) {
+      return super.getManifest(plugin);
+    }
+
+    const distManifest = await super.getManifest({ ...plugin, ref: getDistRef(plugin.ref) });
+    if (distManifest) {
+      return distManifest;
+    }
+
+    return super.getManifest(plugin);
+  }
+}
+
+export async function resolveCronRepoConfig(
+  octokit: ContextPlugin["octokit"],
+  logger: ContextPlugin["logger"],
+  owner: string,
+  repo: string
+): Promise<PluginSettings | null> {
+  try {
+    const handler = new CronConfigurationHandler(logger, octokit);
+    const parsedConfig = await handler.getSelfConfiguration(manifest, { owner, repo });
+    if (!parsedConfig) {
+      return null;
+    }
+
+    const withDefaults = Value.Default(pluginSettingsSchema, parsedConfig);
+    return Value.Decode(pluginSettingsSchema, withDefaults);
+  } catch (err) {
+    logger.error("Failed to resolve repository configuration.", { owner, repo, err });
+    return null;
+  }
+}

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -1,14 +1,12 @@
 import { createAppAuth } from "@octokit/auth-app";
-import { Value } from "@sinclair/typebox/value";
 import { CommentHandler } from "@ubiquity-os/plugin-sdk";
-import { ConfigurationHandler } from "@ubiquity-os/plugin-sdk/configuration";
 import { customOctokit } from "@ubiquity-os/plugin-sdk/octokit";
 import { Logs } from "@ubiquity-os/ubiquity-os-logger";
-import manifest from "../../manifest.json" with { type: "json" };
 import { createKvDatabaseHandler, IssueEntry, KvDatabaseHandler } from "../adapters/kv-database-handler";
+import { resolveCronRepoConfig } from "./configuration";
 import { runRemindersForRepository } from "../handlers/watch-user-activity";
 import { populateDeadlineExtensionsThresholds } from "../run";
-import { ContextPlugin, PluginSettings, pluginSettingsSchema } from "../types/plugin-input";
+import { ContextPlugin, PluginSettings } from "../types/plugin-input";
 
 const RATE_LIMIT_MAX_ITEMS_PER_WINDOW = 500;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -89,18 +87,7 @@ async function getInstallationOctokit(appOctokit: ContextPlugin["octokit"], owne
 }
 
 async function resolveRepoConfig(octokit: ContextPlugin["octokit"], owner: string, repo: string): Promise<PluginSettings | null> {
-  try {
-    const handler = new ConfigurationHandler(logger, octokit);
-    const parsedConfig = await handler.getSelfConfiguration(manifest, { owner, repo });
-    if (!parsedConfig) {
-      return null;
-    }
-    const withDefaults = Value.Default(pluginSettingsSchema, parsedConfig);
-    return Value.Decode(pluginSettingsSchema, withDefaults);
-  } catch (err) {
-    logger.error("Failed to resolve repository configuration.", { owner, repo, err });
-    return null;
-  }
+  return resolveCronRepoConfig(octokit, logger, owner, repo);
 }
 
 function buildCronContext(args: {

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -39,6 +39,124 @@ describe("CRON tests", () => {
     restoreEnv();
   });
 
+  it("Should resolve action manifests from dist refs before the source ref", async () => {
+    const { CronConfigurationHandler } = await import("../src/cron/configuration");
+    const getManifest = spyOn((await import("@ubiquity-os/plugin-sdk/configuration")).ConfigurationHandler.prototype, "getManifest");
+
+    getManifest.mockImplementation(async (plugin) => {
+      if (typeof plugin === "string") {
+        return { short_name: plugin } as never;
+      }
+
+      return plugin.ref === "dist/development" ? ({ short_name: `${plugin.owner}/${plugin.repo}@${plugin.ref}` } as never) : null;
+    });
+
+    const handler = new CronConfigurationHandler(new Logs("debug"), {} as never);
+    const manifest = await handler.getManifest({
+      owner: "ubiquity-os-marketplace",
+      repo: "daemon-disqualifier",
+      workflowId: "compute.yml",
+      ref: "development",
+    });
+
+    expect(manifest).toEqual({
+      short_name: "ubiquity-os-marketplace/daemon-disqualifier@dist/development",
+    });
+    expect(getManifest.mock.calls).toEqual([
+      [
+        {
+          owner: "ubiquity-os-marketplace",
+          repo: "daemon-disqualifier",
+          workflowId: "compute.yml",
+          ref: "dist/development",
+        },
+      ],
+    ]);
+  });
+
+  it("Should fall back to the source ref when the dist manifest is missing", async () => {
+    const { CronConfigurationHandler } = await import("../src/cron/configuration");
+    const getManifest = spyOn((await import("@ubiquity-os/plugin-sdk/configuration")).ConfigurationHandler.prototype, "getManifest");
+
+    getManifest.mockImplementation(async (plugin) => {
+      if (typeof plugin === "string") {
+        return { short_name: plugin } as never;
+      }
+
+      return plugin.ref === "development" ? ({ short_name: `${plugin.owner}/${plugin.repo}@${plugin.ref}` } as never) : null;
+    });
+
+    const handler = new CronConfigurationHandler(new Logs("debug"), {} as never);
+    const manifest = await handler.getManifest({
+      owner: "ubiquity-os-marketplace",
+      repo: "daemon-disqualifier",
+      workflowId: "compute.yml",
+      ref: "development",
+    });
+
+    expect(manifest).toEqual({
+      short_name: "ubiquity-os-marketplace/daemon-disqualifier@development",
+    });
+    expect(getManifest.mock.calls).toEqual([
+      [
+        {
+          owner: "ubiquity-os-marketplace",
+          repo: "daemon-disqualifier",
+          workflowId: "compute.yml",
+          ref: "dist/development",
+        },
+      ],
+      [
+        {
+          owner: "ubiquity-os-marketplace",
+          repo: "daemon-disqualifier",
+          workflowId: "compute.yml",
+          ref: "development",
+        },
+      ],
+    ]);
+  });
+
+  it("Should leave url, worker, dist, and ref-less manifest lookups unchanged", async () => {
+    const { CronConfigurationHandler } = await import("../src/cron/configuration");
+    const getManifest = spyOn((await import("@ubiquity-os/plugin-sdk/configuration")).ConfigurationHandler.prototype, "getManifest").mockResolvedValue(
+      null as never
+    );
+    const handler = new CronConfigurationHandler(new Logs("debug"), {} as never);
+
+    await handler.getManifest("https://example.com/worker");
+    await handler.getManifest({
+      owner: "ubiquity-os-marketplace",
+      repo: "daemon-disqualifier",
+      workflowId: "compute.yml",
+    });
+    await handler.getManifest({
+      owner: "ubiquity-os-marketplace",
+      repo: "daemon-disqualifier",
+      workflowId: "compute.yml",
+      ref: "dist/development",
+    });
+
+    expect(getManifest.mock.calls).toEqual([
+      ["https://example.com/worker"],
+      [
+        {
+          owner: "ubiquity-os-marketplace",
+          repo: "daemon-disqualifier",
+          workflowId: "compute.yml",
+        },
+      ],
+      [
+        {
+          owner: "ubiquity-os-marketplace",
+          repo: "daemon-disqualifier",
+          workflowId: "compute.yml",
+          ref: "dist/development",
+        },
+      ],
+    ]);
+  });
+
   it("Should run reminder sweep directly and clean stale issues", async () => {
     const issue1 = { issueNumber: 1 };
     const issue2 = { issueNumber: 2 };

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -39,16 +39,23 @@ describe("CRON tests", () => {
     restoreEnv();
   });
 
+  function createMockManifest(shortName: string) {
+    return {
+      name: "mock-plugin",
+      short_name: shortName,
+    };
+  }
+
   it("Should resolve action manifests from dist refs before the source ref", async () => {
     const { CronConfigurationHandler } = await import("../src/cron/configuration");
     const getManifest = spyOn((await import("@ubiquity-os/plugin-sdk/configuration")).ConfigurationHandler.prototype, "getManifest");
 
     getManifest.mockImplementation(async (plugin) => {
       if (typeof plugin === "string") {
-        return { short_name: plugin } as never;
+        return createMockManifest(plugin) as never;
       }
 
-      return plugin.ref === "dist/development" ? ({ short_name: `${plugin.owner}/${plugin.repo}@${plugin.ref}` } as never) : null;
+      return plugin.ref === "dist/development" ? (createMockManifest(`${plugin.owner}/${plugin.repo}@${plugin.ref}`) as never) : null;
     });
 
     const handler = new CronConfigurationHandler(new Logs("debug"), {} as never);
@@ -59,9 +66,7 @@ describe("CRON tests", () => {
       ref: "development",
     });
 
-    expect(manifest).toEqual({
-      short_name: "ubiquity-os-marketplace/daemon-disqualifier@dist/development",
-    });
+    expect(manifest).toEqual(createMockManifest("ubiquity-os-marketplace/daemon-disqualifier@dist/development"));
     expect(getManifest.mock.calls).toEqual([
       [
         {
@@ -80,10 +85,10 @@ describe("CRON tests", () => {
 
     getManifest.mockImplementation(async (plugin) => {
       if (typeof plugin === "string") {
-        return { short_name: plugin } as never;
+        return createMockManifest(plugin) as never;
       }
 
-      return plugin.ref === "development" ? ({ short_name: `${plugin.owner}/${plugin.repo}@${plugin.ref}` } as never) : null;
+      return plugin.ref === "development" ? (createMockManifest(`${plugin.owner}/${plugin.repo}@${plugin.ref}`) as never) : null;
     });
 
     const handler = new CronConfigurationHandler(new Logs("debug"), {} as never);
@@ -94,9 +99,7 @@ describe("CRON tests", () => {
       ref: "development",
     });
 
-    expect(manifest).toEqual({
-      short_name: "ubiquity-os-marketplace/daemon-disqualifier@development",
-    });
+    expect(manifest).toEqual(createMockManifest("ubiquity-os-marketplace/daemon-disqualifier@development"));
     expect(getManifest.mock.calls).toEqual([
       [
         {


### PR DESCRIPTION
Resolves #130

## Summary
- add a cron-specific configuration handler that resolves GitHub action manifests from `dist/<ref>` before falling back to the source ref
- keep the change local to cron config loading and preserve existing matching for `daemon-disqualifier@<ref>` config entries
- add cron tests for dist-first lookup, source-ref fallback, and non-rewritten manifest lookups

## Testing
- `bun test --preload=./tests/setup.ts`
