### PR TITLE
ci: migrate deploy workflow to new deno-deploy flow

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -39,18 +39,14 @@ on:
 
 
 jobs:
-  publish-action-artifact:
-    name: "Publish Action Artifact"
+  prepare:
+    name: "Prepare Deployment Context"
     if: ${{ github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
-    permissions: write-all
-    env:
-      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
-      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'false' }}
-      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
-      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
-
-
+    outputs:
+      source_ref: ${{ steps.refs.outputs.source_ref }}
+      is_tag_ref: ${{ steps.refs.outputs.is_tag_ref }}
+      is_artifact_ref: ${{ steps.refs.outputs.is_artifact_ref }}
     steps:
       - name: Resolve source ref
         id: refs
@@ -71,17 +67,22 @@ jobs:
             is_artifact_ref="true"
           fi
 
-          if [[ "$BUILD_ACTION_ENABLED" == "true" ]]; then
-            action_ref_branch="dist/${source_ref}"
-          else
-            action_ref_branch="${source_ref}"
-          fi
-
           echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
           echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
-          echo "ACTION_REF=${GITHUB_REPOSITORY}@${action_ref_branch}" >> "$GITHUB_ENV"
 
+  publish-action-artifact:
+    name: "Publish Action Artifact"
+    needs: prepare
+    if: ${{ github.event_name != 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+    env:
+      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
+      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'false' }}
+      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
+      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
+    steps:
       - name: Print deployment mode
         shell: bash
         run: |
@@ -89,10 +90,9 @@ jobs:
           echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
           echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
           echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
-          echo "SOURCE_REF=${{ steps.refs.outputs.source_ref }}"
-          echo "IS_ARTIFACT_REF=${{ steps.refs.outputs.is_artifact_ref }}"
-          echo "IS_TAG_REF=${{ steps.refs.outputs.is_tag_ref }}"
-          echo "ACTION_REF=${ACTION_REF}"
+          echo "SOURCE_REF=${{ needs.prepare.outputs.source_ref }}"
+          echo "IS_ARTIFACT_REF=${{ needs.prepare.outputs.is_artifact_ref }}"
+          echo "IS_TAG_REF=${{ needs.prepare.outputs.is_tag_ref }}"
 
       - name: Publish action artifact branch
         if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
@@ -108,9 +108,9 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
-
   deploy-deno:
     name: "Provision Deno App"
+    needs: prepare
     if: ${{ github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
     permissions: write-all
@@ -120,39 +120,7 @@ jobs:
       DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'false' }}
       SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
-
-
     steps:
-      - name: Resolve source ref
-        id: refs
-        shell: bash
-        run: |
-          source_ref="$(echo '${{ github.event.ref || github.event.workflow_run.head_branch || github.ref }}' | sed 's#refs/heads/##' | sed 's#refs/tags/##')"
-          if [[ -z "$source_ref" ]]; then
-            source_ref="${GITHUB_REF_NAME}"
-          fi
-
-          is_tag_ref="false"
-          if [[ "${{ github.event.ref_type || '' }}" == "tag" ]] || [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
-            is_tag_ref="true"
-          fi
-
-          is_artifact_ref="false"
-          if [[ "$source_ref" == dist/* ]]; then
-            is_artifact_ref="true"
-          fi
-
-          if [[ "$BUILD_ACTION_ENABLED" == "true" ]]; then
-            action_ref_branch="dist/${source_ref}"
-          else
-            action_ref_branch="${source_ref}"
-          fi
-
-          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
-          echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
-          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
-          echo "ACTION_REF=${GITHUB_REPOSITORY}@${action_ref_branch}" >> "$GITHUB_ENV"
-
       - name: Print deployment mode
         shell: bash
         run: |
@@ -160,23 +128,21 @@ jobs:
           echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
           echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
           echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
-          echo "SOURCE_REF=${{ steps.refs.outputs.source_ref }}"
-          echo "IS_ARTIFACT_REF=${{ steps.refs.outputs.is_artifact_ref }}"
-          echo "IS_TAG_REF=${{ steps.refs.outputs.is_tag_ref }}"
-          echo "ACTION_REF=${ACTION_REF}"
+          echo "SOURCE_REF=${{ needs.prepare.outputs.source_ref }}"
+          echo "IS_ARTIFACT_REF=${{ needs.prepare.outputs.is_artifact_ref }}"
+          echo "IS_TAG_REF=${{ needs.prepare.outputs.is_tag_ref }}"
 
       - uses: actions/checkout@v4
-        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && needs.prepare.outputs.is_tag_ref != 'true' && needs.prepare.outputs.is_artifact_ref != 'true' }}
 
       - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.prepare.outputs.is_tag_ref != 'true' && needs.prepare.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
-          ACTION_REF: ${{ env.ACTION_REF }}
           LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
         with:
           token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -37,7 +37,6 @@ on:
       - deno_deploy.build.routed
   delete:
 
-
 jobs:
   prepare:
     name: "Prepare Deployment Context"

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -83,17 +83,6 @@ jobs:
       SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
     steps:
-      - name: Print deployment mode
-        shell: bash
-        run: |
-          echo "BUILD_ACTION_ENABLED=${BUILD_ACTION_ENABLED}"
-          echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
-          echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
-          echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
-          echo "SOURCE_REF=${{ needs.prepare.outputs.source_ref }}"
-          echo "IS_ARTIFACT_REF=${{ needs.prepare.outputs.is_artifact_ref }}"
-          echo "IS_TAG_REF=${{ needs.prepare.outputs.is_tag_ref }}"
-
       - name: Publish action artifact branch
         if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
         uses: ubiquity-os/action-deploy-plugin@main
@@ -121,17 +110,6 @@ jobs:
       SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
     steps:
-      - name: Print deployment mode
-        shell: bash
-        run: |
-          echo "BUILD_ACTION_ENABLED=${BUILD_ACTION_ENABLED}"
-          echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
-          echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
-          echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
-          echo "SOURCE_REF=${{ needs.prepare.outputs.source_ref }}"
-          echo "IS_ARTIFACT_REF=${{ needs.prepare.outputs.is_artifact_ref }}"
-          echo "IS_TAG_REF=${{ needs.prepare.outputs.is_tag_ref }}"
-
       - uses: actions/checkout@v4
         if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && needs.prepare.outputs.is_tag_ref != 'true' && needs.prepare.outputs.is_artifact_ref != 'true' }}
 

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -160,7 +160,7 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
 
-      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
+      - uses: ubiquity-os/deno-deploy@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -160,7 +160,8 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
 
-      - uses: ubiquity-os/deno-deploy@main
+      - id: deno_deploy
+        uses: ubiquity-os/deno-deploy@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}
@@ -173,3 +174,62 @@ jobs:
           action: ${{ needs.resolve-context.outputs.deno_action }}
           app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: src/worker.ts
+
+      - name: Ensure Deno KV database
+        if: ${{ needs.resolve-context.outputs.deno_action == 'provision' }}
+        shell: bash
+        env:
+          NO_COLOR: "1"
+          DENO_API_TOKEN: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
+          KV_NAME: ${{ github.event.repository.name }}
+          APP_SLUG: ${{ steps.deno_deploy.outputs.app_slug }}
+          ORGANIZATION_SLUG: ${{ steps.deno_deploy.outputs.organization_slug }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$KV_NAME" ]]; then
+            echo "::error::KV_NAME is required."
+            exit 1
+          fi
+
+          if [[ -z "$APP_SLUG" ]]; then
+            echo "::error::App slug output is missing from the Deno deploy step."
+            exit 1
+          fi
+
+          if [[ -z "$ORGANIZATION_SLUG" ]]; then
+            echo "::error::Organization slug output is missing from the Deno deploy step."
+            exit 1
+          fi
+
+          set +e
+          database_list_output="$(deno deploy database list "$KV_NAME" --org "$ORGANIZATION_SLUG" --token "$DENO_API_TOKEN" 2>&1)"
+          database_list_status=$?
+          set -e
+
+          if [[ $database_list_status -ne 0 ]]; then
+            printf '%s\n' "$database_list_output"
+            exit $database_list_status
+          fi
+
+          if printf '%s\n' "$database_list_output" | awk -v name="$KV_NAME" '$1 == name { found=1 } END { exit found ? 0 : 1 }'; then
+            echo "::notice::Deno KV database '$KV_NAME' already exists."
+          else
+            deno deploy database provision "$KV_NAME" --kind denokv --org "$ORGANIZATION_SLUG" --token "$DENO_API_TOKEN"
+          fi
+
+          set +e
+          assign_output="$(deno deploy database assign "$KV_NAME" --app "$APP_SLUG" --org "$ORGANIZATION_SLUG" --token "$DENO_API_TOKEN" 2>&1)"
+          assign_status=$?
+          set -e
+
+          if [[ $assign_status -ne 0 ]]; then
+            if printf '%s\n' "$assign_output" | tr '[:upper:]' '[:lower:]' | grep -Eq 'already (assigned|attached|linked)|already has .*deno kv database assigned'; then
+              echo "::notice::Deno KV database '$KV_NAME' is already assigned to '$APP_SLUG'."
+            else
+              printf '%s\n' "$assign_output"
+              exit $assign_status
+            fi
+          else
+            printf '%s\n' "$assign_output"
+          fi

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -32,20 +32,33 @@ on:
       - "dist/**"
     tags-ignore:
       - "*"
-  repository_dispatch:
-    types:
-      - deno_deploy.build.routed
   delete:
 
 jobs:
-  prepare:
-    name: "Prepare Deployment Context"
-    if: ${{ github.event_name != 'repository_dispatch' }}
+  resolve-context:
+    name: "Resolve Context"
     runs-on: ubuntu-latest
+    permissions: read-all
+    env:
+      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
+      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'false' }}
+      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
+      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
     outputs:
       source_ref: ${{ steps.refs.outputs.source_ref }}
       is_tag_ref: ${{ steps.refs.outputs.is_tag_ref }}
-      is_artifact_ref: ${{ steps.refs.outputs.is_artifact_ref }}
+      is_dist_ref: ${{ steps.refs.outputs.is_dist_ref }}
+      build_action_enabled: ${{ steps.config.outputs.build_action_enabled }}
+      deploy_deno_enabled: ${{ steps.config.outputs.deploy_deno_enabled }}
+      skip_bot_events: ${{ steps.config.outputs.skip_bot_events }}
+      exclude_supported_events: ${{ steps.config.outputs.exclude_supported_events }}
+      should_publish_action_artifact: ${{ steps.config.outputs.should_publish_action_artifact }}
+      should_run_deno: ${{ steps.config.outputs.should_run_deno }}
+      artifact_environment: ${{ steps.config.outputs.artifact_environment }}
+      deno_environment: ${{ steps.config.outputs.deno_environment }}
+      artifact_action: ${{ steps.config.outputs.artifact_action }}
+      deno_action: ${{ steps.config.outputs.deno_action }}
+
     steps:
       - name: Resolve source ref
         id: refs
@@ -61,59 +74,93 @@ jobs:
             is_tag_ref="true"
           fi
 
-          is_artifact_ref="false"
+          is_dist_ref="false"
           if [[ "$source_ref" == dist/* ]]; then
-            is_artifact_ref="true"
+            is_dist_ref="true"
           fi
 
           echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
-          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
+          echo "is_dist_ref=$is_dist_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve deployment settings
+        id: config
+        shell: bash
+        env:
+          SOURCE_REF: ${{ steps.refs.outputs.source_ref }}
+          IS_TAG_REF: ${{ steps.refs.outputs.is_tag_ref }}
+          IS_DIST_REF: ${{ steps.refs.outputs.is_dist_ref }}
+        run: |
+          artifact_environment="development"
+          deno_environment="development"
+          if [[ "$SOURCE_REF" == "main" || "$SOURCE_REF" == "demo" ]]; then
+            artifact_environment="main"
+            deno_environment="main"
+          fi
+
+          artifact_action="publish"
+          deno_action="provision"
+          if [[ "${{ github.event_name }}" == "delete" ]]; then
+            artifact_action="delete"
+            deno_action="delete"
+          fi
+
+          should_publish_action_artifact="false"
+          if [[ "$BUILD_ACTION_ENABLED" == "true" && "$IS_TAG_REF" != "true" && "$IS_DIST_REF" != "true" ]]; then
+            should_publish_action_artifact="true"
+          fi
+
+          should_run_deno="false"
+          if [[ "$DEPLOY_DENO_ENABLED" == "true" && "$IS_TAG_REF" != "true" && "$IS_DIST_REF" != "true" ]]; then
+            should_run_deno="true"
+          fi
+
+          echo "build_action_enabled=$BUILD_ACTION_ENABLED" >> "$GITHUB_OUTPUT"
+          echo "deploy_deno_enabled=$DEPLOY_DENO_ENABLED" >> "$GITHUB_OUTPUT"
+          echo "skip_bot_events=$SKIP_BOT_EVENTS" >> "$GITHUB_OUTPUT"
+          echo "exclude_supported_events=$EXCLUDE_SUPPORTED_EVENTS" >> "$GITHUB_OUTPUT"
+          echo "artifact_environment=$artifact_environment" >> "$GITHUB_OUTPUT"
+          echo "deno_environment=$deno_environment" >> "$GITHUB_OUTPUT"
+          echo "artifact_action=$artifact_action" >> "$GITHUB_OUTPUT"
+          echo "deno_action=$deno_action" >> "$GITHUB_OUTPUT"
+          echo "should_publish_action_artifact=$should_publish_action_artifact" >> "$GITHUB_OUTPUT"
+          echo "should_run_deno=$should_run_deno" >> "$GITHUB_OUTPUT"
 
   publish-action-artifact:
     name: "Publish Action Artifact"
-    needs: prepare
-    if: ${{ github.event_name != 'repository_dispatch' }}
+    needs: resolve-context
+    if: ${{ needs.resolve-context.outputs.should_publish_action_artifact == 'true' }}
     runs-on: ubuntu-latest
     permissions: write-all
-    env:
-      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
-      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'false' }}
-      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
-      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
+    environment: ${{ needs.resolve-context.outputs.artifact_environment }}
+
     steps:
       - name: Publish action artifact branch
-        if: ${{ env.BUILD_ACTION_ENABLED == 'true' }}
         uses: ubiquity-os/action-deploy-plugin@main
         with:
-          action: ${{ github.event_name == 'delete' && 'delete' || 'publish' }}
+          action: ${{ needs.resolve-context.outputs.artifact_action }}
           treatAsEsm: true
           sourcemap: true
           pluginEntry: "${{ github.workspace }}/src/index.ts"
-          excludeSupportedEvents: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}
-          skipBotEvents: ${{ env.SKIP_BOT_EVENTS }}
+          excludeSupportedEvents: ${{ needs.resolve-context.outputs.exclude_supported_events }}
+          skipBotEvents: ${{ needs.resolve-context.outputs.skip_bot_events }}
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   deploy-deno:
     name: "Provision Deno App"
-    needs: prepare
-    if: ${{ github.event_name != 'repository_dispatch' }}
+    needs: resolve-context
+    if: ${{ needs.resolve-context.outputs.should_run_deno == 'true' }}
     runs-on: ubuntu-latest
     permissions: write-all
-    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main' || github.event.ref == 'refs/heads/demo' || github.ref == 'refs/heads/demo' || github.event.workflow_run.head_branch == 'demo') && 'main' || 'development' }}
-    env:
-      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
-      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'false' }}
-      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
-      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
+    environment: ${{ needs.resolve-context.outputs.deno_environment }}
+
     steps:
-      - uses: actions/checkout@v4
-        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && needs.prepare.outputs.is_tag_ref != 'true' && needs.prepare.outputs.is_artifact_ref != 'true' }}
+      - uses: actions/checkout@v6
+        if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
 
       - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && needs.prepare.outputs.is_tag_ref != 'true' && needs.prepare.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}
@@ -123,22 +170,6 @@ jobs:
           LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
         with:
           token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
-          action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
+          action: ${{ needs.resolve-context.outputs.deno_action }}
           app: ${{ secrets.DENO_PROJECT_NAME }}
           entrypoint: src/worker.ts
-
-  publish-deno-manifest:
-    name: "Publish Deno Manifest"
-    if: ${{ github.event_name == 'repository_dispatch' }}
-    runs-on: ubuntu-latest
-    permissions: write-all
-
-    steps:
-      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APP_ID: ${{ secrets.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-        with:
-          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
-          action: publish-manifest

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -148,42 +148,179 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
-  deploy-deno:
-    name: "Provision Deno App"
+  ensure-deno-resources:
+    name: "Ensure Deno App And KV"
     needs: resolve-context
-    if: ${{ needs.resolve-context.outputs.should_run_deno == 'true' }}
+    if: ${{ needs.resolve-context.outputs.deno_action == 'provision' && needs.resolve-context.outputs.is_tag_ref != 'true' && needs.resolve-context.outputs.is_dist_ref != 'true' }}
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions: read-all
     environment: ${{ needs.resolve-context.outputs.deno_environment }}
 
     steps:
-      - uses: actions/checkout@v6
-        if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
-
-      - id: deno_deploy
-        uses: ubiquity-os/deno-deploy@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}
-          APP_ID: ${{ secrets.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-          APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
-          LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
+      - uses: denoland/setup-deno@v2
         with:
-          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
-          action: ${{ needs.resolve-context.outputs.deno_action }}
-          app: ${{ secrets.DENO_PROJECT_NAME }}
-          entrypoint: src/worker.ts
+          deno-version: v2.x
+
+      - name: Resolve Deno app context
+        id: deno_context
+        shell: bash
+        env:
+          SOURCE_REF: ${{ needs.resolve-context.outputs.source_ref }}
+          BASE_APP: ${{ secrets.DENO_PROJECT_NAME }}
+          ORGANIZATION_SLUG: ${{ vars.DENO_ORG_NAME || 'ubiquity-os' }}
+        run: |
+          set -euo pipefail
+
+          slugify() {
+            local value="$1"
+            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            printf '%s' "$value"
+          }
+
+          trim_slug() {
+            local value="$1"
+            local limit="$2"
+            if [ "${#value}" -gt "$limit" ]; then
+              value="${value:0:$limit}"
+            fi
+            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
+            printf '%s' "$value"
+          }
+
+          raw_app="$BASE_APP"
+          if [ -z "$raw_app" ]; then
+            raw_app="${GITHUB_REPOSITORY##*/}"
+          fi
+
+          max_total_length=32
+          base_app_slug="$(slugify "$raw_app")"
+          if [ -z "$base_app_slug" ]; then
+            base_app_slug="app"
+          fi
+          while [ "${#base_app_slug}" -lt 3 ]; do
+            base_app_slug="${base_app_slug}app"
+          done
+          base_app_slug="$(trim_slug "$base_app_slug" "$max_total_length")"
+
+          app_slug="$base_app_slug"
+          if [ "$SOURCE_REF" != "main" ] && [ -n "$SOURCE_REF" ]; then
+            branch_suffix="$(slugify "$SOURCE_REF")"
+            if [ -z "$branch_suffix" ]; then
+              branch_suffix="branch"
+            fi
+
+            max_branch_suffix_length=25
+            available_suffix_budget=$((max_total_length - ${#base_app_slug} - 1))
+            if [ "$available_suffix_budget" -lt 1 ]; then
+              base_app_slug="$(trim_slug "$base_app_slug" $((max_total_length - 2)))"
+              available_suffix_budget=$((max_total_length - ${#base_app_slug} - 1))
+            fi
+
+            suffix_budget="$max_branch_suffix_length"
+            if [ "$available_suffix_budget" -lt "$suffix_budget" ]; then
+              suffix_budget="$available_suffix_budget"
+            fi
+            if [ "$suffix_budget" -lt 1 ]; then
+              suffix_budget=1
+            fi
+
+            branch_suffix="$(trim_slug "$branch_suffix" "$suffix_budget")"
+            if [ -z "$branch_suffix" ]; then
+              branch_suffix="b"
+            fi
+
+            app_slug="${base_app_slug}-${branch_suffix}"
+          fi
+
+          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
+          echo "organization_slug=$ORGANIZATION_SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure Deno app exists
+        shell: bash
+        env:
+          DENO_API_TOKEN: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
+          DENO_API_BASE_URL: "https://api.deno.com"
+          APP_SLUG: ${{ steps.deno_context.outputs.app_slug }}
+          ENTRYPOINT: "src/worker.ts"
+          REF_NAME: ${{ needs.resolve-context.outputs.source_ref }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          deno eval --ext js '
+          const token = Deno.env.get("DENO_API_TOKEN")?.trim();
+          const baseUrl = Deno.env.get("DENO_API_BASE_URL")?.trim() || "https://api.deno.com";
+          const appSlug = Deno.env.get("APP_SLUG")?.trim();
+          const entrypoint = Deno.env.get("ENTRYPOINT")?.trim() || "src/worker.ts";
+          const refName = Deno.env.get("REF_NAME")?.trim();
+          const repository = Deno.env.get("REPOSITORY")?.trim();
+
+          if (!token) throw new Error("DENO_API_TOKEN is required.");
+          if (!appSlug) throw new Error("APP_SLUG is required.");
+          if (!refName) throw new Error("REF_NAME is required.");
+          if (!repository) throw new Error("REPOSITORY is required.");
+
+          const headers = {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json",
+          };
+
+          const existingResponse = await fetch(`${baseUrl}/v2/apps/${encodeURIComponent(appSlug)}`, {
+            headers,
+          });
+
+          if (existingResponse.status === 404) {
+            const payload = {
+              slug: appSlug,
+              config: {
+                install: "deno install",
+                build: `deno x -y @ubiquity-os/plugin-manifest-tool@latest --repository ${repository} --production-branch main`,
+                predeploy: "deno install",
+                unstable: ["kv"],
+                runtime: {
+                  type: "dynamic",
+                  entrypoint,
+                },
+              },
+              env_vars: [
+                { key: "REF_NAME", value: refName, secret: false, contexts: ["production"] },
+                { key: "PLUGIN_MANIFEST_PRODUCTION_BRANCH", value: "main", secret: false, contexts: ["build"] },
+                { key: "PLUGIN_MANIFEST_REPOSITORY", value: repository, secret: false, contexts: ["build"] },
+                { key: "REF_NAME", value: refName, secret: false, contexts: ["build"] },
+              ],
+            };
+
+            const createResponse = await fetch(`${baseUrl}/v2/apps`, {
+              method: "POST",
+              headers: {
+                ...headers,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(payload),
+            });
+
+            if (!createResponse.ok) {
+              const body = await createResponse.text();
+              throw new Error(`Deno API POST /v2/apps failed (${createResponse.status}): ${body || "<empty response>"}`);
+            }
+
+            console.log(`Created Deno app "${appSlug}".`);
+          } else if (!existingResponse.ok) {
+            const body = await existingResponse.text();
+            throw new Error(`Deno API GET /v2/apps/${appSlug} failed (${existingResponse.status}): ${body || "<empty response>"}`);
+          } else {
+            console.log(`Deno app "${appSlug}" already exists.`);
+          }
+          '
 
       - name: Ensure Deno KV database
-        if: ${{ needs.resolve-context.outputs.deno_action == 'provision' }}
         shell: bash
         env:
           NO_COLOR: "1"
           DENO_API_TOKEN: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
           KV_NAME: ${{ github.event.repository.name }}
-          APP_SLUG: ${{ steps.deno_deploy.outputs.app_slug }}
-          ORGANIZATION_SLUG: ${{ steps.deno_deploy.outputs.organization_slug }}
+          APP_SLUG: ${{ steps.deno_context.outputs.app_slug }}
+          ORGANIZATION_SLUG: ${{ steps.deno_context.outputs.organization_slug }}
         run: |
           set -euo pipefail
 
@@ -193,12 +330,12 @@ jobs:
           fi
 
           if [[ -z "$APP_SLUG" ]]; then
-            echo "::error::App slug output is missing from the Deno deploy step."
+            echo "::error::App slug output is missing from the Deno context step."
             exit 1
           fi
 
           if [[ -z "$ORGANIZATION_SLUG" ]]; then
-            echo "::error::Organization slug output is missing from the Deno deploy step."
+            echo "::error::Organization slug is required."
             exit 1
           fi
 
@@ -233,3 +370,30 @@ jobs:
           else
             printf '%s\n' "$assign_output"
           fi
+
+  deploy-deno:
+    name: "Provision Deno App"
+    needs: resolve-context
+    if: ${{ needs.resolve-context.outputs.should_run_deno == 'true' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+    environment: ${{ needs.resolve-context.outputs.deno_environment }}
+
+    steps:
+      - uses: actions/checkout@v6
+        if: ${{ needs.resolve-context.outputs.deno_action != 'delete' }}
+
+      - id: deno_deploy
+        uses: ubiquity-os/deno-deploy@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KERNEL_PUBLIC_KEY: ${{ secrets.KERNEL_PUBLIC_KEY }}
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_INSTALLATION_ID: ${{ secrets.APP_INSTALLATION_ID }}
+          LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
+        with:
+          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
+          action: ${{ needs.resolve-context.outputs.deno_action }}
+          app: ${{ secrets.DENO_PROJECT_NAME }}
+          entrypoint: src/worker.ts

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -32,19 +32,24 @@ on:
       - "dist/**"
     tags-ignore:
       - "*"
+  repository_dispatch:
+    types:
+      - deno_deploy.build.routed
   delete:
 
+
 jobs:
-  deploy:
-    name: "Deploy (Action / Deno)"
+  publish-action-artifact:
+    name: "Publish Action Artifact"
+    if: ${{ github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
     permissions: write-all
-    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main' || github.event.ref == 'refs/heads/demo' || github.ref == 'refs/heads/demo' || github.event.workflow_run.head_branch == 'demo') && 'main' || 'development' }}
     env:
       BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
       DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'false' }}
       SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
       EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
+
 
     steps:
       - name: Resolve source ref
@@ -103,35 +108,67 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Check out the repository
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
-        uses: actions/checkout@v6
 
-      - name: Set up Deno
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
+  deploy-deno:
+    name: "Provision Deno App"
+    if: ${{ github.event_name != 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+    environment: ${{ (github.event.ref == 'refs/heads/main' || github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main' || github.event.ref == 'refs/heads/demo' || github.ref == 'refs/heads/demo' || github.event.workflow_run.head_branch == 'demo') && 'main' || 'development' }}
+    env:
+      BUILD_ACTION_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.build_action_enabled || vars.BUILD_ACTION_ENABLED || 'true' }}
+      DEPLOY_DENO_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_deno_enabled || vars.DEPLOY_DENO_ENABLED || 'false' }}
+      SKIP_BOT_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_bot_events || vars.SKIP_BOT_EVENTS || 'false' }}
+      EXCLUDE_SUPPORTED_EVENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.exclude_supported_events || vars.EXCLUDE_SUPPORTED_EVENTS || '' }}
 
-      - name: Install dependencies
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        run: deno install --node-modules-dir=auto --no-lock
 
-      - name: Generate manifest for deploy
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        run: deno x -A -y --no-lock npm:@ubiquity-os/plugin-manifest-tool@latest
-        env:
-          SKIP_BOT_EVENTS: ${{ env.SKIP_BOT_EVENTS }}
-          EXCLUDE_SUPPORTED_EVENTS: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}
-          GITHUB_REF_NAME: ${{ steps.refs.outputs.source_ref }}
+    steps:
+      - name: Resolve source ref
+        id: refs
+        shell: bash
+        run: |
+          source_ref="$(echo '${{ github.event.ref || github.event.workflow_run.head_branch || github.ref }}' | sed 's#refs/heads/##' | sed 's#refs/tags/##')"
+          if [[ -z "$source_ref" ]]; then
+            source_ref="${GITHUB_REF_NAME}"
+          fi
 
-      - uses: ubiquity-os/deno-plugin-adapter@main
-        if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' && github.event_name != 'delete' }}
-        id: adapter
-        with:
-          pluginEntry: "./worker"
+          is_tag_ref="false"
+          if [[ "${{ github.event.ref_type || '' }}" == "tag" ]] || [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+            is_tag_ref="true"
+          fi
 
-      - uses: ubiquity-os/deno-deploy@main
+          is_artifact_ref="false"
+          if [[ "$source_ref" == dist/* ]]; then
+            is_artifact_ref="true"
+          fi
+
+          if [[ "$BUILD_ACTION_ENABLED" == "true" ]]; then
+            action_ref_branch="dist/${source_ref}"
+          else
+            action_ref_branch="${source_ref}"
+          fi
+
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
+          echo "is_tag_ref=$is_tag_ref" >> "$GITHUB_OUTPUT"
+          echo "is_artifact_ref=$is_artifact_ref" >> "$GITHUB_OUTPUT"
+          echo "ACTION_REF=${GITHUB_REPOSITORY}@${action_ref_branch}" >> "$GITHUB_ENV"
+
+      - name: Print deployment mode
+        shell: bash
+        run: |
+          echo "BUILD_ACTION_ENABLED=${BUILD_ACTION_ENABLED}"
+          echo "DEPLOY_DENO_ENABLED=${DEPLOY_DENO_ENABLED}"
+          echo "SKIP_BOT_EVENTS=${SKIP_BOT_EVENTS}"
+          echo "EXCLUDE_SUPPORTED_EVENTS=${EXCLUDE_SUPPORTED_EVENTS}"
+          echo "SOURCE_REF=${{ steps.refs.outputs.source_ref }}"
+          echo "IS_ARTIFACT_REF=${{ steps.refs.outputs.is_artifact_ref }}"
+          echo "IS_TAG_REF=${{ steps.refs.outputs.is_tag_ref }}"
+          echo "ACTION_REF=${ACTION_REF}"
+
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'delete' && env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
+
+      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
         if: ${{ env.DEPLOY_DENO_ENABLED == 'true' && steps.refs.outputs.is_tag_ref != 'true' && steps.refs.outputs.is_artifact_ref != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -142,10 +179,23 @@ jobs:
           ACTION_REF: ${{ env.ACTION_REF }}
           LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
         with:
-          token: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          action: ${{ github.event_name == 'delete' && 'delete' || 'deploy' }}
-          organization: ${{ secrets.DENO_ORG_NAME }}
-          entrypoint: ${{ github.event_name == 'delete' && 'src/deno.ts' || steps.adapter.outputs.entrypoint }}
-          project_name: ${{ secrets.DENO_PROJECT_NAME }}
-          sourceRef: ${{ steps.refs.outputs.source_ref }}
-          artifactPrefix: dist/
+          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
+          action: ${{ github.event_name == 'delete' && 'delete' || 'provision' }}
+          app: ${{ secrets.DENO_PROJECT_NAME }}
+          entrypoint: src/worker.ts
+
+  publish-deno-manifest:
+    name: "Publish Deno Manifest"
+    if: ${{ github.event_name == 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    steps:
+      - uses: ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        with:
+          token: ${{ secrets.DENO_2_DEPLOY_TOKEN }}
+          action: publish-manifest

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@sinclair/typebox": "0.34.41",
         "@ubiquity-os/plugin-sdk": "3.12.5",
         "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
+        "hono": "^4.12.12",
         "luxon": "3.4.4",
         "ms": "2.1.3",
       },
@@ -698,7 +699,7 @@
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
-    "hono": ["hono@4.11.3", "", {}, "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w=="],
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
@@ -1183,6 +1184,8 @@
     "@ubiquity-os/plugin-sdk/@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
 
     "@ubiquity-os/plugin-sdk/@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@ubiquity-os/plugin-sdk/hono": ["hono@4.11.3", "", {}, "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w=="],
 
     "@ubiquity-os/plugin-sdk/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@octokit/graphql-schema": "^15.26.1",
         "@octokit/rest": "^22.0.1",
         "@sinclair/typebox": "0.34.41",
-        "@ubiquity-os/plugin-sdk": "^3.12.0",
+        "@ubiquity-os/plugin-sdk": "3.12.5",
         "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
         "luxon": "3.4.4",
         "ms": "2.1.3",
@@ -410,7 +410,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.21.0", "", { "dependencies": { "@typescript-eslint/types": "8.21.0", "eslint-visitor-keys": "^4.2.0" } }, "sha512-BkLMNpdV6prozk8LlyK/SOoWLmUFi+ZD+pcqti9ILCbVvHGk1ui1g4jJOc2WDLaeExz2qWwojxlPce5PljcT3w=="],
 
-    "@ubiquity-os/plugin-sdk": ["@ubiquity-os/plugin-sdk@3.12.0", "", { "dependencies": { "@actions/core": "^1.11.1", "@actions/github": "^6.0.1", "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.1.3", "@ubiquity-os/ubiquity-os-logger": "^1.4.0", "hono": "^4.10.6", "js-yaml": "^4.1.1", "ms": "^2.1.3", "openai": "^6.15.0" }, "peerDependencies": { "@sinclair/typebox": "0.34.41" } }, "sha512-/NfB1a0X+U4/fH9R+xTxfS/GasBjZ7h70jPRNoQrRkkHBXibnrEJr5xRT0HLyBz12cmzWTdKHOQxPYMTLmFxHQ=="],
+    "@ubiquity-os/plugin-sdk": ["@ubiquity-os/plugin-sdk@3.12.5", "", { "dependencies": { "@actions/core": "^1.11.1", "@actions/github": "^6.0.1", "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.1.3", "@ubiquity-os/ubiquity-os-logger": "^1.4.0", "hono": "^4.10.6", "js-yaml": "^4.1.1", "ms": "^2.1.3", "openai": "^6.15.0" }, "peerDependencies": { "@sinclair/typebox": "0.34.41" } }, "sha512-T1TAdD6rZDVrRELrEiQWM5bBRdzvFzMD+o6lthCahlGkvTOG3xxPHe8iXVnYrq60qnnMTrlUGm/uV9cIujZZ5A=="],
 
     "@ubiquity-os/ubiquity-os-logger": ["@ubiquity-os/ubiquity-os-logger@1.4.0", "", {}, "sha512-giybluPmu0sreEWi60t9X8NxC5d48X7oQAb9RjXR7wX/ZNYugbAaKgj0TYEqECvSVDqgzpKo7UNerh1UQBscGw=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@octokit/graphql-schema": "^15.26.1",
     "@octokit/rest": "^22.0.1",
     "@sinclair/typebox": "0.34.41",
-    "@ubiquity-os/plugin-sdk": "^3.12.0",
+    "@ubiquity-os/plugin-sdk": "3.12.5",
     "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
     "luxon": "3.4.4",
     "ms": "2.1.3"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@sinclair/typebox": "0.34.41",
     "@ubiquity-os/plugin-sdk": "3.12.5",
     "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
+    "hono": "^4.12.12",
     "luxon": "3.4.4",
     "ms": "2.1.3"
   },

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,26 +1,42 @@
 import { createPlugin } from "@ubiquity-os/plugin-sdk";
-import { Manifest } from "@ubiquity-os/plugin-sdk/manifest";
+import { Manifest, resolveRuntimeManifest } from "@ubiquity-os/plugin-sdk/manifest";
 import { LOG_LEVEL } from "@ubiquity-os/ubiquity-os-logger";
+import { ExecutionContext } from "hono";
 import manifest from "../manifest.json" with { type: "json" };
 import { run } from "./run";
 import { Env, envSchema, PluginSettings, pluginSettingsSchema, SupportedEvents } from "./types/plugin-input";
 
-const app = createPlugin<PluginSettings, Env, null, SupportedEvents>(
-  (context) => {
-    return run(context);
-  },
-  manifest as Manifest,
-  {
-    envSchema: envSchema,
-    settingsSchema: pluginSettingsSchema,
-    logLevel: process.env.LOG_LEVEL || LOG_LEVEL.INFO,
-    postCommentOnError: false,
-    kernelPublicKey: process.env.KERNEL_PUBLIC_KEY,
-    bypassSignatureVerification: process.env.NODE_ENV === "local",
-  }
-);
+function buildRuntimeManifest(request: Request) {
+  const runtimeManifest = resolveRuntimeManifest(manifest as Manifest);
+  return {
+    ...runtimeManifest,
+    homepage_url: new URL(request.url).origin,
+  };
+}
 
 export default {
-  fetch: app.fetch,
+  async fetch(request: Request, env: Env, executionCtx?: ExecutionContext) {
+    const runtimeManifest = buildRuntimeManifest(request);
+    if (new URL(request.url).pathname === "/manifest.json") {
+      return Response.json(runtimeManifest);
+    }
+
+    const app = createPlugin<PluginSettings, Env, null, SupportedEvents>(
+      (context) => {
+        return run(context);
+      },
+      runtimeManifest,
+      {
+        envSchema: envSchema,
+        settingsSchema: pluginSettingsSchema,
+        logLevel: process.env.LOG_LEVEL || LOG_LEVEL.INFO,
+        postCommentOnError: false,
+        kernelPublicKey: process.env.KERNEL_PUBLIC_KEY,
+        bypassSignatureVerification: process.env.NODE_ENV === "local",
+      }
+    );
+
+    return app.fetch(request, env, executionCtx);
+  },
   port: 4000,
 };

--- a/tests/__mocks__/handlers.ts
+++ b/tests/__mocks__/handlers.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { db } from "./db";
-import issuesLabelsGet from "./routes/get-labels.json";
-import issueTimeline from "./routes/get-timeline.json";
+import issuesLabelsGet from "./routes/get-labels.json" with { type: "json" };
+import issueTimeline from "./routes/get-timeline.json" with { type: "json" };
 
 /**
  * Intercepts the routes and returns a custom payload

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -17,7 +17,7 @@ import { db } from "./__mocks__/db";
 import { handlers } from "./__mocks__/handlers";
 import { createComment, createEvent, createIssue, createRepo, ONE_DAY } from "./__mocks__/helpers";
 import mockUsers from "./__mocks__/mock-users";
-import cfg from "./__mocks__/results/valid-configuration.json";
+import cfg from "./__mocks__/results/valid-configuration.json" with { type: "json" };
 import { botReminderComment, getIssueHtmlUrl, STRINGS } from "./__mocks__/strings";
 
 const server = setupServer(...handlers);


### PR DESCRIPTION
## Summary
- switch the deploy workflow to the new `provision` / `publish-manifest` / `delete` deno-deploy flow
- add the routed Deno manifest publication trigger
- replace the legacy deployctl-era inputs with the new Deno Deploy action inputs

## Notes
- this references `ubiquity-os/deno-deploy@issue-17-deno-deploy-app-migration` until that PR is merged
- this workflow now expects `DENO_2_DEPLOY_TOKEN`

Closes ubiquity-os/deno-deploy#17
Depends on ubiquity-os/deno-deploy#30