### PR TITLE
fix: skip reminder on issue reopen when no assignee

### DIFF
--- a/src/handlers/watch-user-activity.ts
+++ b/src/handlers/watch-user-activity.ts
@@ -16,6 +16,10 @@ export async function watchUserActivity(context: ContextPlugin) {
     "issue" in context.payload &&
     !shouldIgnoreIssue(context.payload.issue as IssueType)
   ) {
+    const issue = context.payload.issue as IssueType;
+    if (!issue.assignees?.length && !issue.assignee) {
+      return { message: logger.info("Skipping reminder: no assignee on the issue.").logMessage.raw };
+    }
     const message = ["[!IMPORTANT]"];
     const priorityValue = getPriorityValue(context);
     if (context.config.pullRequestRequired) {


### PR DESCRIPTION
## Summary

Fixes #135 — When an issue is reopened without any assignees, the plugin was incorrectly posting a reminder comment. This adds an early return that skips the reminder when no assignee is present.

## Changes

- Added an assignee check at the top of the `watchUserActivity` handler (after `shouldIgnoreIssue` passes)
- If neither `issue.assignees` nor `issue.assignee` is populated, returns early with an info log
- This aligns the event-driven path with the existing CRON-based `updateReminders` function which already skips unassigned issues (line 89-95)

## Test plan

- [ ] Trigger `issues.reopened` event on an issue with no assignee → no reminder comment posted
- [ ] Trigger `issues.reopened` event on an issue with an assignee → reminder comment posted as before
- [ ] Trigger `issues.assigned` event → still works normally (assignee always present)