### PR TITLE
fix: skip reminder on reopened issues without assignee

### DIFF
--- a/src/handlers/watch-user-activity.ts
+++ b/src/handlers/watch-user-activity.ts
@@ -16,6 +16,12 @@ export async function watchUserActivity(context: ContextPlugin) {
     "issue" in context.payload &&
     !shouldIgnoreIssue(context.payload.issue as IssueType)
   ) {
+    // For reopened events, only post reminder if there are assignees
+    const issue = context.payload.issue as IssueType;
+    if (context.eventName === "issues.reopened" && !issue.assignees?.length && !issue.assignee) {
+      context.logger.debug(`Skipping reminder for reopened issue ${issue.html_url} because no user is assigned.`);
+      return { message: "OK" };
+    }
     const message = ["[!IMPORTANT]"];
     const priorityValue = getPriorityValue(context);
     if (context.config.pullRequestRequired) {


### PR DESCRIPTION
## Problem

When a PR is reopened but the issue has no assignees, the reminder is still posted. This is incorrect behavior — reminders should only be sent when there are assignees to remind.

## Solution

Add a check for assignees before posting the reminder for reopened events:
- For `issues.reopened` events, check if the issue has assignees
- If no assignees, skip the reminder and return early
- For `issues.assigned` events, the reminder is still posted as expected

Fixes #135