### PR TITLE
fix: skip reopened reminders without assignees

### DIFF
--- a/src/handlers/watch-user-activity.ts
+++ b/src/handlers/watch-user-activity.ts
@@ -14,7 +14,7 @@ export async function watchUserActivity(context: ContextPlugin) {
   if (
     ["issues.assigned", "issues.reopened"].includes(context.eventName) &&
     "issue" in context.payload &&
-    !shouldIgnoreIssue(context.payload.issue as IssueType)
+    !shouldIgnoreIssue(context.payload.issue as IssueType, context.eventName)
   ) {
     const message = ["[!IMPORTANT]"];
     const priorityValue = getPriorityValue(context);
@@ -54,9 +54,18 @@ export async function runRemindersForRepository(context: ContextPlugin, repo: Co
  * - locked
  * - not in "open" state
  * - not priced (no price label found)
+ * - reopened without any assignee to notify
  */
-function shouldIgnoreIssue(issue: IssueType) {
-  return issue.draft || !!issue.pull_request || issue.locked || issue.state !== "open" || parsePriceLabel(issue.labels) === null;
+function shouldIgnoreIssue(issue: IssueType, eventName?: string) {
+  const hasAssignee = !!(issue.assignees?.length || issue.assignee);
+  return (
+    issue.draft ||
+    !!issue.pull_request ||
+    issue.locked ||
+    issue.state !== "open" ||
+    parsePriceLabel(issue.labels) === null ||
+    (eventName === "issues.reopened" && !hasAssignee)
+  );
 }
 
 async function updateReminders(context: ContextPlugin, repo: ContextPlugin["payload"]["repository"]) {

--- a/tests/assign.test.ts
+++ b/tests/assign.test.ts
@@ -63,6 +63,30 @@ describe("watchUserActivity", () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 
+  it("should not post a reminder when an unassigned task is reopened", async () => {
+    const mockContext = {
+      ...mockContextTemplate,
+      eventName: "issues.reopened",
+      payload: {
+        ...mockContextTemplate.payload,
+        issue: {
+          assignees: [],
+          assignee: null,
+          title: "Unassigned task",
+          state: "open",
+          labels: ["Price: 75 USD"],
+        },
+      },
+      commentHandler: {
+        postComment: mock(() => {}),
+      },
+    } as unknown as ContextPlugin;
+
+    await watchUserActivity(mockContext);
+
+    expect(mockContext.commentHandler.postComment).not.toHaveBeenCalled();
+  });
+
   it("should ignore an un-priced task", async () => {
     const infoSpy = spyOn(console, "info");
     await watchUserActivity(mockContextTemplate);


### PR DESCRIPTION
Fixes #135

## Summary
- Skip posting reopened-task reminder comments when the issue has no assignee.
- Preserve existing behavior for assigned priced tasks.
- Add a regression test for an unassigned priced task reopened event.

## Verification
- `bun test --preload=./tests/setup.ts tests/assign.test.ts`
- `bunx tsc --noEmit`
