### PR TITLE
fix: skip reopen reminder when issue has no assignee

### DIFF
--- a/src/handlers/watch-user-activity.ts
+++ b/src/handlers/watch-user-activity.ts
@@ -16,6 +16,9 @@ export async function watchUserActivity(context: ContextPlugin) {
     "issue" in context.payload &&
     !shouldIgnoreIssue(context.payload.issue as IssueType)
   ) {
+    if (context.eventName === "issues.reopened" && !context.payload.issue.assignees?.length && !(context.payload.issue as IssueType).assignee) {
+      return { message: logger.info("Issue reopened with no assignee, skipping reminder.").logMessage.raw };
+    }
     const message = ["[!IMPORTANT]"];
     const priorityValue = getPriorityValue(context);
     if (context.config.pullRequestRequired) {

--- a/tests/assign.test.ts
+++ b/tests/assign.test.ts
@@ -68,4 +68,26 @@ describe("watchUserActivity", () => {
     await watchUserActivity(mockContextTemplate);
     expect(infoSpy).not.toHaveBeenCalled();
   });
+
+  it("should NOT post a reminder when issue is reopened with no assignee", async () => {
+    const postCommentSpy = spyOn(mockContextTemplate.commentHandler, "postComment");
+    const mockContext = {
+      ...mockContextTemplate,
+      eventName: "issues.reopened",
+      payload: {
+        ...mockContextTemplate.payload,
+        issue: {
+          assignees: [],
+          assignee: null,
+          title: "Test Issue",
+          state: "open",
+          labels: [{ name: "Price: 75 USD" }],
+        },
+      },
+    } as unknown as ContextPlugin;
+
+    const result = await watchUserActivity(mockContext);
+    expect(postCommentSpy).not.toHaveBeenCalled();
+    expect(result.message).toContain("no assignee");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #135

When `issues.reopened` fires on a priced issue that has no assignees, `watchUserActivity` was posting a reminder comment — despite there being nobody to remind.

## Root Cause

The event handler checked `shouldIgnoreIssue` (draft / PR / locked / unpriced) but had no guard for the absence of an assignee on reopened events. The CRON path (`updateReminders`) already handles this correctly by checking `issue.assignees?.length || issue.assignee` before calling `updateTaskReminder`.

## Fix

Added an early return guard at the top of the `issues.reopened` branch in `watchUserActivity`. If the event is `issues.reopened` and neither `issue.assignees` (array) nor `issue.assignee` is populated, return early with an info log — matching CRON behavior.

## Test

Added regression test in `tests/assign.test.ts`:
- `issues.reopened` + priced open issue + `assignees: []` + `assignee: null`
- Asserts `postComment` is **not** called
- Asserts return message contains `'no assignee'`

All 3 existing tests continue to pass.