### PR TITLE
fix: skip reopen reminder when issue has no assignee

### DIFF
--- a/src/handlers/watch-user-activity.ts
+++ b/src/handlers/watch-user-activity.ts
@@ -8,6 +8,14 @@ import { formatMillisecondsToHumanReadable } from "./time-format";
 
 type IssueType = RestEndpointMethodTypes["issues"]["listForRepo"]["response"]["data"]["0"];
 
+/**
+ * Handles user activity watching for task assignment and reopening events.
+ * Posts reminder comments when issues are assigned or reopened, and
+ * initializes the CRON reminder state. Skips unpriced, locked, draft,
+ * or unassigned issues to avoid spurious notifications.
+ * @param context - The plugin context containing event payload, config, and adapters.
+ * @returns A result object with a log message string.
+ */
 export async function watchUserActivity(context: ContextPlugin) {
   const { logger } = context;
 
@@ -16,6 +24,15 @@ export async function watchUserActivity(context: ContextPlugin) {
     "issue" in context.payload &&
     !shouldIgnoreIssue(context.payload.issue as IssueType)
   ) {
+    /**
+     * Early return for reopened issues with no assignee.
+     * Mirrors the CRON-path guard in {@link updateReminders} which skips
+     * unassigned issues to avoid posting reminders with nobody to notify.
+     * @see updateReminders
+     */
+    if (context.eventName === "issues.reopened" && !context.payload.issue.assignees?.length && !(context.payload.issue as IssueType).assignee) {
+      return { message: logger.info("Issue reopened with no assignee, skipping reminder.").logMessage.raw };
+    }
     const message = ["[!IMPORTANT]"];
     const priorityValue = getPriorityValue(context);
     if (context.config.pullRequestRequired) {
@@ -40,6 +57,13 @@ export async function watchUserActivity(context: ContextPlugin) {
   return { message: logger.warn(`Unsupported event ${context.eventName}`).logMessage.raw };
 }
 
+/**
+ * Runs the full reminder pipeline for all open issues in a repository.
+ * Called by the CRON workflow to check activity and send follow-up reminders.
+ * @param context - The plugin context.
+ * @param repo - The repository to scan for open assigned issues.
+ * @returns A result object with a log message string.
+ */
 export async function runRemindersForRepository(context: ContextPlugin, repo: ContextPlugin["payload"]["repository"]) {
   context.logger.info(`> Watching user activity for repo: ${repo.name} (${repo.html_url})`);
   await updateReminders(context, repo);

--- a/tests/assign.test.ts
+++ b/tests/assign.test.ts
@@ -68,4 +68,26 @@ describe("watchUserActivity", () => {
     await watchUserActivity(mockContextTemplate);
     expect(infoSpy).not.toHaveBeenCalled();
   });
+
+  it("should NOT post a reminder when issue is reopened with no assignee", async () => {
+    const postCommentSpy = spyOn(mockContextTemplate.commentHandler, "postComment");
+    const mockContext = {
+      ...mockContextTemplate,
+      eventName: "issues.reopened",
+      payload: {
+        ...mockContextTemplate.payload,
+        issue: {
+          assignees: [],
+          assignee: null,
+          title: "Test Issue",
+          state: "open",
+          labels: [{ name: "Price: 75 USD" }],
+        },
+      },
+    } as unknown as ContextPlugin;
+
+    const result = await watchUserActivity(mockContext);
+    expect(postCommentSpy).not.toHaveBeenCalled();
+    expect(result.message).toContain("no assignee");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #135

When `issues.reopened` fires on a priced issue that has no assignees, `watchUserActivity` was posting a reminder comment — despite there being nobody to remind.

## Root Cause

The event handler checked `shouldIgnoreIssue` (draft / PR / locked / unpriced) but had no guard for the absence of an assignee on reopened events. The CRON path (`updateReminders`) already handles this correctly by checking `issue.assignees?.length || issue.assignee` before calling `updateTaskReminder`.

## Fix

Added an early return guard at the top of the `issues.reopened` branch in `watchUserActivity`. If the event is `issues.reopened` and neither `issue.assignees` (array) nor `issue.assignee` is populated, return early with an info log — matching CRON behavior.

## Test

Added regression test in `tests/assign.test.ts`:
- `issues.reopened` + priced open issue + `assignees: []` + `assignee: null`
- Asserts `postComment` is **not** called
- Asserts return message contains `'no assignee'`

All 3 existing tests continue to pass.

---

**Note:** Added JSDoc docstrings to satisfy documentation coverage threshold.