### PR TITLE
Skip reopened reminder setup when a task has no assignee

### DIFF
--- a/src/handlers/watch-user-activity.ts
+++ b/src/handlers/watch-user-activity.ts
@@ -54,9 +54,17 @@ export async function runRemindersForRepository(context: ContextPlugin, repo: Co
  * - locked
  * - not in "open" state
  * - not priced (no price label found)
+ * - no assigned user
  */
 function shouldIgnoreIssue(issue: IssueType) {
-  return issue.draft || !!issue.pull_request || issue.locked || issue.state !== "open" || parsePriceLabel(issue.labels) === null;
+  return (
+    issue.draft ||
+    !!issue.pull_request ||
+    issue.locked ||
+    issue.state !== "open" ||
+    parsePriceLabel(issue.labels) === null ||
+    !(issue.assignees?.length || issue.assignee)
+  );
 }
 
 async function updateReminders(context: ContextPlugin, repo: ContextPlugin["payload"]["repository"]) {

--- a/tests/assign.test.ts
+++ b/tests/assign.test.ts
@@ -68,4 +68,30 @@ describe("watchUserActivity", () => {
     await watchUserActivity(mockContextTemplate);
     expect(infoSpy).not.toHaveBeenCalled();
   });
+
+  it("should ignore a reopened task with no assignee", async () => {
+    const postComment = mock(() => undefined);
+    const mockContext = {
+      ...mockContextTemplate,
+      eventName: "issues.reopened",
+      payload: {
+        ...mockContextTemplate.payload,
+        issue: {
+          assignee: null,
+          assignees: [],
+          title: "Unassigned reopened task",
+          state: "open",
+          locked: false,
+          labels: ["Price: 75 USD"],
+        },
+      },
+      commentHandler: {
+        postComment,
+      },
+    } as unknown as ContextPlugin;
+
+    await watchUserActivity(mockContext);
+
+    expect(postComment).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Skip `issues.assigned` / `issues.reopened` reminder setup when the task has no current assignee.
- Prevent reopened unassigned tasks from posting reminder comments or being re-added to the reminder store.
- Add coverage for a reopened priced task with no `assignee` and an empty `assignees` list.

## Validation
- TypeScript 5.5.4 syntax check passed for `src/handlers/watch-user-activity.ts` and `tests/assign.test.ts`.
- Full `bun test` not run locally because Bun is not installed in this environment.

Resolves #135
